### PR TITLE
Link to librt

### DIFF
--- a/scikits/umfpack/setup.py
+++ b/scikits/umfpack/setup.py
@@ -11,6 +11,11 @@ def configuration(parent_package='',top_path=None):
 
     umf_info = get_info('umfpack', notfound_action=1)
 
+    ## The following addition is needed when linking against a umfpack built
+    ## from the latest SparseSuite. Not (strictly) needed when linking against
+    ## the version in the ubuntu repositories.
+    umf_info['libraries'].insert(0, 'rt')
+
     umfpack_i_file = config.paths('umfpack.i')[0]
 
     def umfpack_i(ext, build_dir):


### PR DESCRIPTION
When building and linking to the latest SuiteSparse I found that you
needed to additionally link to librt.

Otherwise you get various errors on certain symbols not being found. I
noticed that sage and octave users where having similar problems.

Here is an example of the problems people were having https://savannah.gnu.org/bugs/?37031

I personally saw errors related to missing clock_gettime functions.